### PR TITLE
Fixes reading config file from home directory

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,17 +9,14 @@ import (
 // Config contains the token for the discord bot
 type Config struct {
 	Token string
-	DB string
+	DB    string
 }
 
 // Get reads in the config file and returns a struct
 func Get() *Config {
 	options := viper.New()
 
-	options.SetConfigFile("botconfig")
-	// TODO: find out why viper seems to only be able to read config from .
-	// For now just put your config wherever you run repbot from
-	options.AddConfigPath(".")
+	options.SetConfigName("botconfig")
 	options.AddConfigPath("$HOME/.config/repbot-go/")
 	options.AddConfigPath("./config/")
 	options.SetConfigType("yaml")
@@ -30,6 +27,6 @@ func Get() *Config {
 
 	return &Config{
 		Token: options.GetString("token"),
-		DB: options.GetString("db"),
+		DB:    options.GetString("db"),
 	}
 }

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"syscall"
 
-	config "./config"
+	"github.com/SteveHNH/repbot-go/config"
 	"github.com/bwmarrin/discordgo"
 	_ "github.com/mattn/go-sqlite3"
 )


### PR DESCRIPTION
Replaces `SetConfigFile()`, which assumes a full path + filename with `SetConfigName()`, which sets the name of the config file, allowing viper to construct the path with `AddConfigPath()` + `SetConfigName()`.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>